### PR TITLE
ignore files with 100% coverage

### DIFF
--- a/bin/flow-stats
+++ b/bin/flow-stats
@@ -80,7 +80,7 @@ glob(argv.glob, (err, files) => {
       files.map(file => getCoverage(file))
     ).then(files => {
       const sorted =
-        Array.from(files).sort((a, b) => b.covered - a.covered);
+        Array.from(files).filter(a => a.covered < 100).sort((a, b) => b.covered - a.covered);
 
       prettyPrint(sorted);
     });


### PR DESCRIPTION
In our case, we end up having Flow only check for files with the @flow pragma, however, this is globbing for everything, therefore non-flow files will display coverage of 100% or NaN (for whatever reason -- these get coerced to numbers by the `<` operator). filtering these values makes sense, since we really might only care about files that require additional coverage. This code change can optionally be controlled by a flag as well if that's preferred.

thoughts?